### PR TITLE
ci: Enable code linting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,5 +9,7 @@ env:
 jobs:
   format_code:
     uses: ./.github/workflows/ci_format_code.yml
+  lint:
+    uses: ./.github/workflows/ci_lint.yml
   test:
     uses: ./.github/workflows/ci_test.yml

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -1,0 +1,11 @@
+name: CI Lint
+'on':
+  workflow_call: null
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@v4
+      - name: Cargo Clippy
+        run: cargo clippy --all-targets --all-features -- -Dwarnings


### PR DESCRIPTION
I treated all warnings as errors, as @DS424 would have liked that as a start.
We can always reduce strictness later on.