### PR TITLE
ci(devcontainer): Make the devcontainer build deterministic

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,5 @@
 # ros:humble
 FROM ros@sha256:0dd6b5d4a9b113e543f8b3ea1d837e2bbf20e706398c3dd4bea5b245a4a8ec1e
-ARG DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Changing the base image of a docker image results in the necessity of rebuilding the image.
The consequence is, that whenever ROS bumps their docker image, our CI Pipeline has to rebuild the image of the devcontainer.
This is not a big deal on main, since we built once and publish it to our docker registry which serves as a cache for the other builds.
However, if the ROS docker image bump happens while working on a PR/Branch, the devcontainer image has to be rebuild every time a job is triggered (because only images from main are published to our registry) until eventually the main job is triggered.

With the changes from this PR, the ROS docker image is pinned to a specific version, meaning bumping the base ROS docker image is a controlled process.

Closes: [RR-735]

[RR-735]: https://vorausrobotik.atlassian.net/browse/RR-735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ