### PR TITLE
feat!: Drop node from create_joint_state_msg

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), RclrsError> {
     let mut increment = 0.0;
     thread::spawn(move || loop {
         thread::sleep(Duration::from_micros(publisher_thread_throttle_us));
-        let joint_state_msg = create_joint_state_msg(&node, increment);
+        let joint_state_msg = create_joint_state_msg(increment);
         joint_state_publisher
             .publish_data(&joint_state_msg)
             .unwrap();

--- a/src/ros_publisher.rs
+++ b/src/ros_publisher.rs
@@ -25,7 +25,7 @@ impl<T: RosMessage> RosPublisher<T> {
     }
 }
 
-pub fn create_joint_state_msg(_node: &Node, data: f64) -> JointStateMsg {
+pub fn create_joint_state_msg(data: f64) -> JointStateMsg {
     let system_timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
     // Workaround for https://github.com/ros2-rust/ros2_rust/issues/385
     let time_msgs = TimeMsg {


### PR DESCRIPTION
This was used to access the ROS nodes system clock.

Resolves [RR-739]

[RR-739]: https://vorausrobotik.atlassian.net/browse/RR-739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ