### PR TITLE
feat: Implement an 'example' rapid-clock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ socket2 = "0.5.7"
 tokio = "1.38.0"
 
 [[example]]
+name = "rapid-clock"
+path = "examples/opc_ua/rapid-clock.rs"
+
+[[example]]
 name = "simple-publisher"
 path = "examples/ros2/simple-publisher.rs"
 

--- a/examples/opc_ua/rapid-clock.rs
+++ b/examples/opc_ua/rapid-clock.rs
@@ -1,0 +1,63 @@
+use opcua::server::prelude::{Config, DateTime, NodeId, Server, ServerConfig, Variable};
+use std::path::PathBuf;
+
+fn main() {
+    rapid_clock();
+}
+
+fn rapid_clock() {
+    opcua::console_logging::init();
+
+    let mut server =
+        Server::new(ServerConfig::load(&PathBuf::from("tests/resources/clock.conf")).unwrap());
+
+    let namespace = {
+        let address_space = server.address_space();
+        let mut address_space = address_space.write();
+        address_space.register_namespace("urn:rapid-clock").unwrap()
+    };
+
+    add_timed_variable(&mut server, namespace);
+
+    server.run();
+}
+
+fn add_timed_variable(server: &mut Server, namespace: u16) {
+    // These will be the node ids of the new variables
+    let ticks_since_launch_node_id = NodeId::new(namespace, "ticks_since_launch");
+
+    let address_space = server.address_space();
+
+    // The address space is guarded so obtain a lock to change it
+    {
+        let mut address_space = address_space.write();
+
+        let rapid_folder_id = address_space
+            .add_folder("Rapid", "Rapid", &NodeId::objects_folder_id())
+            .unwrap();
+
+        let _ = address_space.add_variables(
+            vec![Variable::new(
+                &ticks_since_launch_node_id,
+                "ticks_since_launch",
+                "ticks_since_launch",
+                0i32,
+            )],
+            &rapid_folder_id,
+        );
+    }
+
+    {
+        server.add_polling_action(10, move || {
+            let mut address_space = address_space.write();
+            let now = DateTime::now();
+            let ticks_in_100_ns = now.ticks();
+            let _ = address_space.set_variable_value(
+                ticks_since_launch_node_id.clone(),
+                ticks_in_100_ns as i32,
+                &now,
+                &now,
+            );
+        });
+    }
+}


### PR DESCRIPTION
> which is basically a utility to spawn rapid OPC UA variable changes on a subscribable server. It might better reside in the upstream OPC UA crate eventually.