### PR TITLE
refactor: Use `Arc::clone()` instead of `.clone()`

### DIFF
--- a/examples/ros2/simple-publisher.rs
+++ b/examples/ros2/simple-publisher.rs
@@ -89,5 +89,5 @@ fn main() -> Result<(), RclrsError> {
             .publish_data(sine.next().unwrap())
             .unwrap();
     });
-    rclrs::spin(publisher.node.clone())
+    rclrs::spin(Arc::clone(&publisher.node))
 }

--- a/examples/ros2/simple-subscriber.rs
+++ b/examples/ros2/simple-subscriber.rs
@@ -54,5 +54,5 @@ impl Subscriber {
 fn main() -> Result<(), RclrsError> {
     let subscription =
         Arc::new(Subscriber::new("joint_states_subscriber", "joint_states").unwrap());
-    rclrs::spin(subscription.node.clone())
+    rclrs::spin(Arc::clone(&subscription.node))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use ros_publisher::{create_joint_state_msg, RosPublisher};
 fn main() -> Result<(), RclrsError> {
     let context = Context::new(env::args()).unwrap();
     let node = create_node(&context, "voraus_bridge_node")?;
-    let node_copy = node.clone();
+    let node_copy = Arc::clone(&node);
     let joint_state_publisher = Arc::new(RosPublisher::new(&node, "joint_states").unwrap());
 
     let _server = node_copy


### PR DESCRIPTION
in order to clearly mark that no costly deepcopy is performed.