### PR TITLE
feat!: Alter OPC UA node_id to let its respective namespace be 1

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn main() -> Result<(), RclrsError> {
         }
     };
     simple_subscriber
-        .create_subscription(2, "ticks_since_launch", callback, 10)
+        .create_subscription(1, "100111", callback, 10)
         .expect("ERROR: Got an error while subscribing to variables");
     // Loops forever. The publish thread will call the callback with changes on the variables
     simple_subscriber.run();

--- a/tests/helpers/opc_ua_publisher_single_linear.rs
+++ b/tests/helpers/opc_ua_publisher_single_linear.rs
@@ -14,20 +14,16 @@ fn rapid_clock() {
     let mut server =
         Server::new(ServerConfig::load(&PathBuf::from("tests/resources/clock.conf")).unwrap());
 
-    let namespace = {
-        let address_space = server.address_space();
-        let mut address_space = address_space.write();
-        address_space.register_namespace("urn:rapid-clock").unwrap()
-    };
+    let questionable_namespace = 1u16;
 
-    add_timed_variable(&mut server, namespace);
+    add_timed_variable(&mut server, questionable_namespace);
 
     server.run();
 }
 
 fn add_timed_variable(server: &mut Server, namespace: u16) {
     // These will be the node ids of the new variables
-    let ticks_since_launch_node_id = NodeId::new(namespace, "ticks_since_launch");
+    let ticks_since_launch_node_id = NodeId::new(namespace, "100111");
 
     let address_space = server.address_space();
 


### PR DESCRIPTION
> in order to verify this does not collide with the default namespace.