### PR TITLE
feat!: Use numeric node IDs

### DIFF
--- a/examples/opc_ua/rapid-clock.rs
+++ b/examples/opc_ua/rapid-clock.rs
@@ -20,7 +20,7 @@ fn rapid_clock() {
 
 fn add_timed_variable(server: &mut Server, namespace: u16) {
     // These will be the node ids of the new variables
-    let ticks_since_launch_node_id = NodeId::new(namespace, "100111");
+    let ticks_since_launch_node_id = NodeId::new(namespace, 100111);
 
     let address_space = server.address_space();
 

--- a/examples/opc_ua/sine-joint-positions.rs
+++ b/examples/opc_ua/sine-joint-positions.rs
@@ -21,7 +21,7 @@ fn sine_joint_positions() {
 
 fn add_timed_variable_array(server: &mut Server) {
     // These will be the node id of the variable AxesMeasuredPosition
-    let axes_measured_position = NodeId::new(1, "100111");
+    let axes_measured_position = NodeId::new(1, 100111);
 
     let address_space = server.address_space();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ fn main() -> Result<(), RclrsError> {
     opc_ua_client
         .lock()
         .unwrap()
-        .create_subscription(1, "100111", callback, 10.0)
+        .create_subscription(1, 100111, callback, 10.0)
         .expect("ERROR: Got an error while subscribing to variables");
     // Loops forever. The publish thread will call the callback with changes on the variables
     info!("Starting OPC UA client");

--- a/src/opc_ua_client.rs
+++ b/src/opc_ua_client.rs
@@ -64,7 +64,7 @@ impl OPCUAClient {
     pub fn create_subscription<F>(
         &self,
         namespace: u16,
-        node_id: &'static str,
+        node_id: u32,
         callback: F,
         period_ms: f64,
     ) -> Result<(), StatusCode>

--- a/tests/helpers/opc_ua_publisher_single_linear.rs
+++ b/tests/helpers/opc_ua_publisher_single_linear.rs
@@ -33,7 +33,7 @@ fn rapid_clock() {
 
 fn add_timed_variable(server: &mut Server, namespace: u16) {
     // These will be the node ids of the new variables
-    let ticks_since_launch_node_id = NodeId::new(namespace, "100111");
+    let ticks_since_launch_node_id = NodeId::new(namespace, 100111);
 
     let address_space = server.address_space();
 


### PR DESCRIPTION
because the robot control uses them and they are
distinct from string IDs.