### PR TITLE
build: Use `0.12.1` of the `voraus` fork of `opcua`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,6 +458,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,11 +524,11 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -661,7 +667,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -683,8 +689,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 [[package]]
 name = "opcua"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df8d714e27ba497815bf1d41f79b7652804d54ef5132ef1fc553fbd03598c81"
+source = "git+https://github.com/vorausrobotik/opcua?rev=0.12.1#451a075b6545e7bac28cdd64228965bbcc1e8dcd"
 dependencies = [
  "base64",
  "bitflags",
@@ -1308,11 +1313,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["command-line-utilities"]
 
 
 [dependencies]
-opcua = { version = "0.12.0", features = ["client", "console-logging"] }
+opcua = { git = "https://github.com/vorausrobotik/opcua", rev="0.12.1", features = ["client", "console-logging"] }
 # Explicitly pinning openssl >= 0.10.66 is required, as long as opcua is not 0.13.0, yet.
 openssl = { version = "0.10.66" }
 std_msgs = { version = "4.2.4" }
@@ -34,7 +34,7 @@ rclrs = { version = "0.4.1" }
 std_msgs = { version = "4.2.4" }
 sensor_msgs = { version = "4.2.4" }
 builtin_interfaces = { version = "1.2.1" }
-opcua = { version = "0.12.0", features = ["server", "console-logging"] }
+opcua = { git = "https://github.com/vorausrobotik/opcua", rev="0.12.1", features = ["server", "console-logging"] }
 socket2 = "0.5.7"
 tokio = "1.38.0"
 


### PR DESCRIPTION
mainly because the increased client polling rate is needed.

Closes: [RR-811]

[RR-811]: https://vorausrobotik.atlassian.net/browse/RR-811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ