### PR TITLE
ci: Avoid recompiling for building release image

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -21,3 +21,10 @@ jobs:
           push: never
       - name: Verify no build induced changes in Cargo.lock
         run: git diff && git diff --quiet -- Cargo.lock
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ros-binaries
+          path: |
+            install/voraus-ros-bridge
+            voraus_interfaces/install/voraus_interfaces

--- a/.github/workflows/ci_build_release_image.yml
+++ b/.github/workflows/ci_build_release_image.yml
@@ -13,12 +13,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Cargo build
-        uses: devcontainers/ci@v0.3
+      - name: Download ROS binaries from previous build step
+        uses: actions/download-artifact@v4
         with:
-          cacheFrom: ghcr.io/vorausrobotik/voraus-ros-bridge-dev
-          runCmd: cargo ament-build --install-base install/voraus-ros-bridge -- --release
-          push: never
+          name: ros-binaries
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
Use the release artifacts of the build job instead of recompiling.