### PR TITLE
chore: Make the binary excecutable within the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ COPY package.xml /root/voraus-ros-bridge/
 COPY ./install/voraus-ros-bridge/ /root/voraus-ros-bridge/install/voraus-ros-bridge/
 COPY ./launch/* /root/voraus-ros-bridge/install/voraus-ros-bridge/share/voraus-ros-bridge/
 COPY ./voraus_interfaces/install/voraus_interfaces/lib/* /opt/ros/humble/lib/
+RUN chmod +x /root/voraus-ros-bridge/install/voraus-ros-bridge/lib/voraus-ros-bridge/voraus-ros-bridge
 


### PR DESCRIPTION
Apparently, the artifact GitHub action changes the permissions. Therefore, we explicitly set the execute permission on the `voraus-ros-bridge` binary.
See https://github.com/actions/download-artifact?tab=readme-ov-file#permission-loss
