### PR TITLE
test: Add generic service type support to the service caller

### DIFF
--- a/tests/helpers/ros_service_caller.rs
+++ b/tests/helpers/ros_service_caller.rs
@@ -5,32 +5,35 @@ use std::{
     time::Duration,
 };
 
-pub struct ServiceCaller {
-    pub client: Arc<rclrs::Client<std_srvs::srv::Empty>>,
+pub struct ServiceCaller<Srv>
+where
+    Srv: rosidl_runtime_rs::Service,
+{
+    pub client: Arc<rclrs::Client<Srv>>,
     pub node: Arc<Node>,
-    pub request: std_srvs::srv::Empty_Request,
+    pub request: Srv::Request,
     pub number_of_calls: Arc<Mutex<u32>>,
 }
 
-impl ServiceCaller {
+impl<Srv> ServiceCaller<Srv>
+where
+    Srv: rosidl_runtime_rs::Service,
+    Srv::Request: Default,
+{
     pub fn new(service: &str) -> Result<Arc<Self>, RclrsError> {
         let context = rclrs::Context::new(env::args())?;
-
         let node = rclrs::create_node(&context, "minimal_client")?;
+        let client = node.create_client::<Srv>(service)?;
 
-        let client = node.create_client::<std_srvs::srv::Empty>(service)?;
-
-        let request = std_srvs::srv::Empty_Request {
-            structure_needs_at_least_one_member: 0,
-        };
-        let action_caller = Arc::new(ServiceCaller {
+        let request = Srv::Request::default();
+        let service_caller = Arc::new(ServiceCaller {
             client,
             node,
             request,
             number_of_calls: Arc::new(Mutex::new(0)),
         });
 
-        Ok(action_caller)
+        Ok(service_caller)
     }
 
     pub fn start(&self) {
@@ -38,16 +41,14 @@ impl ServiceCaller {
             std::thread::sleep(std::time::Duration::from_millis(10));
         }
     }
+
     pub fn call(&self) {
         let num_calls_clone = Arc::clone(&self.number_of_calls);
         self.client
-            .async_send_request_with_callback(
-                &self.request,
-                move |_response: std_srvs::srv::Empty_Response| {
-                    let mut num_calls = num_calls_clone.lock().unwrap();
-                    *num_calls += 1;
-                },
-            )
+            .async_send_request_with_callback(&self.request, move |_response: Srv::Response| {
+                let mut num_calls = num_calls_clone.lock().unwrap();
+                *num_calls += 1;
+            })
             .unwrap();
 
         let timeout = Some(Duration::new(5, 0));

--- a/tests/test_bridge_methods.rs
+++ b/tests/test_bridge_methods.rs
@@ -5,12 +5,13 @@ use std::{
 
 use common::{wait_for_function_to_pass, ManagedRosBridge};
 use helpers::opc_ua_test_server::OPCUATestServer;
+use std_srvs::srv::Empty;
 
 pub mod common;
 pub mod helpers;
 
 macro_rules! make_testcase_method {
-    ($value:expr, $testname:ident) => {
+    ($value:expr, $service_type:path, $testname:ident) => {
         #[test]
         fn $testname() {
             let (assertion_tx, assertion_rx) = mpsc::channel();
@@ -20,7 +21,7 @@ macro_rules! make_testcase_method {
                 ManagedRosBridge::new(None).expect("Failed to start subprocess");
 
             let service_caller = Arc::new(
-                helpers::ros_service_caller::ServiceCaller::new(&format!(
+                helpers::ros_service_caller::ServiceCaller::<$service_type>::new(&format!(
                     "/voraus_bridge_node/{}",
                     $value
                 ))
@@ -52,5 +53,13 @@ macro_rules! make_testcase_method {
     };
 }
 
-make_testcase_method!("impedance_control/enable", test_enable_impedance_control);
-make_testcase_method!("impedance_control/disable", test_disable_impedance_control);
+make_testcase_method!(
+    "impedance_control/enable",
+    Empty,
+    test_enable_impedance_control
+);
+make_testcase_method!(
+    "impedance_control/disable",
+    Empty,
+    test_disable_impedance_control
+);


### PR DESCRIPTION
In order to be able to call arbitrary ROS services (with arbitrary arguments) from within the integration tests against the ROS bridge, we need the `ros_service_caller` to be suitable for every service type, not just empty.
Hence, the service caller was templated.
