### PR TITLE
build(voraus_interfaces): Distinguish between `srv` and `msg` files

### DIFF
--- a/voraus_interfaces/CMakeLists.txt
+++ b/voraus_interfaces/CMakeLists.txt
@@ -15,13 +15,17 @@ find_package(rosidl_default_generators REQUIRED)
 find_package(geometry_msgs REQUIRED)
 
 set(msg_files
-  "msg/Voraus.msg"
   "msg/CartesianStiffness.msg"
+  "msg/Voraus.msg"
+)
+
+set(srv_files
   "srv/Voraus.srv"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
+  ${srv_files}
   DEPENDENCIES geometry_msgs
 )
 


### PR DESCRIPTION
Explicitly distinguish between service files and message files in the `CMakeLists.txt`.